### PR TITLE
Config: add Aragon Chain configuration

### DIFF
--- a/src/network-config.js
+++ b/src/network-config.js
@@ -114,6 +114,23 @@ export const networkConfigs = {
       portisDappId ? { id: 'portis', conf: portisDappId } : null,
     ].filter(p => p),
   },
+  aragonchain: {
+    addresses: {
+      ensRegistry:
+        localEnsRegistryAddress || '0x96661e0CBB4E5Fd9608f11c12D411F9661851012',
+    },
+    nodes: {
+      defaultEth: 'ws://localhost:8545',
+    },
+    settings: {
+      chainId: 8,
+      name: 'Aragon Chain',
+      shortName: 'aragonchain',
+      type: 'private',
+      live: false,
+    },
+    providers: [{ id: 'provided' }, { id: 'frame' }],
+  },
   unknown: {
     addresses: {
       ensRegistry: localEnsRegistryAddress,


### PR DESCRIPTION
The PR adds a new configuration for Aragon Chain. The current default ENS address is from my own deployment `0x96661e0CBB4E5Fd9608f11c12D411F9661851012`. Probably once the internal tests net has an ENS we should update to that one instead.

In the meanwhile to test Aragon Chain network the client should be started with:
```
ARAGON_ENS_REGISTRY_ADDRESS=<ENS_ADDRESS_DEPLOYED> ARAGON_ETH_NETWORK_TYPE=aragonchain yarn start
```